### PR TITLE
bug fix: node's mass should be 1+degree(node)

### DIFF
--- a/fa2l/fa2l.py
+++ b/fa2l/fa2l.py
@@ -119,7 +119,7 @@ def force_atlas2_layout(graph,
     for i in range(0, G.shape[0]):
         n = Node()
         if node_masses is None:
-            n.mass = 1 + numpy.sum(G[i])
+            n.mass = 1 + numpy.count_nonzero(G[i])
         else:
             n.mass = masses[i]
         n.old_dx = 0


### PR DESCRIPTION
Node's mass should be 1+degree(node) instead of 1+sum(edge_weights(node))
Reference: [ForceAtlas2](https://github.com/gephi/gephi/blob/master/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2.java)
